### PR TITLE
Using a list instead of an iterator

### DIFF
--- a/src/getseqfrombed.py
+++ b/src/getseqfrombed.py
@@ -114,7 +114,7 @@ reffile=sys.argv[-1];
 
 # build reference
 seqref=SeqIO.index(reffile,'fasta');
-refkeys=seqref.keys();
+refkeys = list(seqref.keys())
 
 # read bed file, and ready for writing
 if bedfile!="-":


### PR DESCRIPTION
Convert the iterator seqref.keys() into a list and put that into refkeys. Otherwise, "if not bedfield[0] in refkeys:" will always complain the chromosome is not in refkeys. This is probably due to recent changes in Biopython.
